### PR TITLE
Text pane: select monospace font

### DIFF
--- a/Scripts/Scratchpad/ScratchpadWindow.dlg
+++ b/Scripts/Scratchpad/ScratchpadWindow.dlg
@@ -167,6 +167,10 @@ dialog = {
                                 [1] = {
                                     ["bkg"] = {
                                         ["center_center"] = "0x00000080"
+                                    },
+                                    ["text"] = {
+                                        ["font"] = "CONSOLA.TTF",
+                                        ["lineHeight"] = 10
                                     }
                                 }
                             }


### PR DESCRIPTION
Use Consolas (CONSOLA.TTF) as the font for the scratchpad text box.
This allows for more easily formatting tabular data like a flight
plan or other sequential information.