### PR TITLE
Fixed bug when insertcoord button assigned but prev is not

### DIFF
--- a/Scripts/Hooks/scratchpad-hook.lua
+++ b/Scripts/Hooks/scratchpad-hook.lua
@@ -543,7 +543,7 @@ local function loadScratchpad()
         )
 
         -- add insert coordinates hotkey
-        if config.hotkeyPrevPage then
+        if config.hotkeyInsertCoordinates then
             window:addHotKeyCallback(
                 config.hotkeyInsertCoordinates,
                 function()
@@ -593,7 +593,7 @@ local function loadScratchpad()
             end
 
             -- add next page hotkey
-            if config.hotkeyPrevPage then
+            if config.hotkeyNextPage then
                 window:addHotKeyCallback(
                     config.hotkeyNextPage,
                     function()


### PR DESCRIPTION
The next and insertcoord key depends on prev being defined, which I dont think is intended. Also it leads to unexpected behavior from users perspective. This change just makes a check for definition before callback assignment.