### PR TITLE
Added other types of listeners, frame and missionloadend

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ addButton(left, top, width, height, title, onClick(text))
   text:insertBelowCursor(text)
   text:insertTop(text)
   text:insertBottom(text)
+
+-- Provides the start and end offsets of the current selection from page being displayed. No argements
+-- passed. Accomodates multibyte characters.
+getSelection() - return 4 numbers: start, end, startByte, endByte
+
+-- Provides the value of the currentPage variable or the page being displayed. This is full path and file
+-- name of the page shown. Takes no arguments.
+getCurrentPage() - returns string
+
+-- Each extension can register a text string to be displayed on the titlebar. It will share the titlebar
+-- with other extension notices, if any, and the page name. Currently no guarantee is made about how much
+-- of the string is displayed. A page notice is not requied for extension use.
+setPageNotice(text) - text: string to display
+                      returns nothing
 ```
 
 ## Kudos

--- a/Scripts/Hooks/scratchpad-hook.lua
+++ b/Scripts/Hooks/scratchpad-hook.lua
@@ -33,6 +33,7 @@ local function loadScratchpad()
     local currentPage = nil
     local pagesCount = 0
     local pages = {}
+    local pagesnotice = ''
 
     -- Crosshair resources
     local crosshairWindow = nil
@@ -330,6 +331,30 @@ local function loadScratchpad()
         self:insert("")
     end
 
+    local function setTitleBar(page)
+        window:setText(page.name .. ' | '..pagesnotice)
+    end
+
+    local function setPageNotice(str)
+        pagesnotice = str
+        setTitleBar(pages[1])
+        return
+        --[[
+        for _,page in pairs(pages) do
+            if page.name == string.sub(string.match(currentPage,'[%w+]+.txt'),1, -5) then
+                page.notice = str
+                setTitleBar(page)
+                return
+            end
+        end
+        log('setPageNotice: page not found '..currentPage)
+        --]]
+    end
+
+    local function getcurrentPage()
+        return currentPage
+    end
+
     local function loadPage(page)
         log("loading page " .. page.path)
         file, err = io.open(page.path, "r")
@@ -342,7 +367,7 @@ local function loadScratchpad()
             textarea:setText(content)
 
             -- update title
-            window:setText(page.name)
+            setTitleBar(page)
         end
     end
 
@@ -474,7 +499,8 @@ local function loadScratchpad()
                         pages,
                         {
                             name = name:sub(1, -5),
-                            path = path
+                            path = path,
+                            notice = '',
                         }
                     )
                     pagesCount = pagesCount + 1
@@ -495,6 +521,7 @@ local function loadScratchpad()
             )
             pagesCount = pagesCount + 1
         end
+        pagesnotice = ''
     end
 
     local function unlockKeyboardInput()
@@ -810,7 +837,9 @@ local function loadScratchpad()
                 end,
                 formatCoord = formatCoord,
                 log = log,
-                getSelection = getSelection
+                getSelection = getSelection,
+                setPageNotice = setPageNotice,
+                getcurrentPage = getcurrentPage,
             }
             setmetatable(extEnv, {__index = _G})
             setfenv(f, extEnv)

--- a/Scripts/Hooks/scratchpad-hook.lua
+++ b/Scripts/Hooks/scratchpad-hook.lua
@@ -535,13 +535,13 @@ local function loadScratchpad()
         keyboardLocked = true
     end
 
-        local function runListeners(list)
-            for _, listener in pairs(list) do
-                if type(listener) == "function" then
-                        listener()
-                end
-            end
-        end
+    local function runListeners(list)
+	for _, listener in pairs(list) do
+	    if type(listener) == "function" then
+		listener()
+	    end
+	end
+    end
 
     function formatCoord(format, isLat, d, opts)
         local function showNegative(d, h)

--- a/Scripts/Hooks/scratchpad-hook.lua
+++ b/Scripts/Hooks/scratchpad-hook.lua
@@ -536,11 +536,11 @@ local function loadScratchpad()
     end
 
     local function runListeners(list)
-	for _, listener in pairs(list) do
-	    if type(listener) == "function" then
-		listener()
-	    end
-	end
+        for _, listener in pairs(list) do
+            if type(listener) == "function" then
+                listener()
+            end
+        end
     end
 
     function formatCoord(format, isLat, d, opts)

--- a/Scripts/Hooks/scratchpad-hook.lua
+++ b/Scripts/Hooks/scratchpad-hook.lua
@@ -354,7 +354,16 @@ local function loadScratchpad()
         else
             table.delete(pagesnotice, extid)
         end
-        setTitleBar(pages[1])
+        if not currentPage then
+            return
+        end
+
+        for _,page in pairs(pages) do
+            if page.path == currentPage then
+                setTitleBar(page)
+                return
+            end
+        end
     end
 
     local function loadPage(page)
@@ -834,13 +843,13 @@ local function loadScratchpad()
                 addFrameListener = function(listener)
                     frameListeners[extid] = listener
                 end,
-                addmissionLoadEndListener = function(listener)
+                addMissionLoadEndListener = function(listener)
                     table.insert(missionLoadEndListeners, listener)
                 end,
                 formatCoord = formatCoord,
                 log = log,
                 getSelection = getSelection,
-                getcurrentPage = function()
+                getCurrentPage = function()
                     return currentPage
                 end,
                 extid = extid,


### PR DESCRIPTION
This change is to add a couple types of listeners to scratchpad. These are needed for an extension to integrate cockpit macro management, which will be submitted in a separate PR.