### PR TITLE
 Fixes: av8 and Text:insertBottom

### DIFF
--- a/Scripts/Hooks/scratchpad-hook.lua
+++ b/Scripts/Hooks/scratchpad-hook.lua
@@ -313,7 +313,9 @@ local function loadScratchpad()
 
         local text = self:getText()
         setSelection(#text)
-        self:insert("\n\n" .. newText .. "\n")
+        if #newText > 0 then
+            self:insert("\n\n" .. newText .. "\n")
+        end
     end
 
     function Text:deleteBackward()
@@ -565,26 +567,28 @@ local function loadScratchpad()
         local g = math.floor(d)
         local m = d * 60 - g * 60
 
+        local precision = 3
+        if opts.precision ~= nil then
+            precision = opts.precision
+        end
+        if opts.showNegative ~= nil then
+            g, h = showNegative(g, h)
+        end
+        local degreesWidth = 2
+        if opts.lonDegreesWidth ~= nil and not isLat then
+            degreesWidth = opts.lonDegreesWidth
+            if opts.showNegative ~= nil and g < 0 then
+                degreesWidth = degreesWidth + 1
+            end
+        end
+
         if format == "DMS" then -- Degree Minutes Seconds
             m = math.floor(m)
             local s = d * 3600 - g * 3600 - m * 60
             s = math.floor(s * 100) / 100
-            return string.format('%s %2d°%.2d\'%05.2f"', h, g, m, s)
+            return string.format('%s %0'..degreesWidth..'d°%.2d\'%0'..(precision+2)..'.'..precision..'f', h, g, m, s)
+
         elseif format == "DDM" then -- Degree Decimal Minutes
-            local precision = 3
-            if opts.precision ~= nil then
-                precision = opts.precision
-            end
-            if opts.showNegative ~= nil then
-                g, h = showNegative(g, h)
-            end
-            local degreesWidth = 2
-            if opts.lonDegreesWidth ~= nil and not isLat then
-                degreesWidth = opts.lonDegreesWidth
-                if opts.showNegative ~= nil and g < 0 then
-                    degreesWidth = degreesWidth + 1
-                end
-            end
             return string.format('%s %0'..degreesWidth..'d°%0'..(precision+3)..'.'..precision..'f\'', h, g, m)
         else -- Decimal Degrees
             return  string.format('%f', showNegative(d, h))
@@ -599,8 +603,10 @@ local function loadScratchpad()
         local ac = DCS.getPlayerUnitType()
         if ac == "FA-18C_hornet" then
             return {DMS = true, DDM = {precision = 4}, MGRS = true}
-        elseif string.sub(ac, 1, 5) == "A-10C" or ac == "AV-8B" then
+        elseif string.sub(ac, 1, 5) == "A-10C" then
             return {DDM = true, MGRS = true}
+        elseif ac == "AV8BNA" then
+            return {DMS = {precision = 0, lonDegreesWidth = 3}, MGRS = true}
         elseif string.sub(ac, 1, 4) == "F-14" then
             return {DDM = {precision = 1}}
         elseif ac == "F-15ESE" then


### PR DESCRIPTION
-- changed formatCoord to handle opts for DMS the same as DDM. This was
   needed to fix Harrier coord format, #56

-- fix for Text:insertBottom when called with newText="".  This allows
   scrolling to bottom of buffer w/o adding new lines
   every time.

For reference here are the formats for several types:
--herc
N 41°55.689', E 041°51.846'
18m, 59ft

--av8
N 41°55'38, E 041°51'34
37 T GG 37083 45657
18m, 59ft

--f16
N 41°55.627', E 041°51.453'
37 T GG 36935 45633
18m, 59ft

--f18
N 41°55'37.770, E 41°51'28.440
N 41°55.6295', E 41°51.4740'
37 T GG 36964 45639
18m, 59ft

--f15C
N 41°55'37.960, E 41°51'29.710
N 41°55.633', E 41°51.495'
37 T GG 36994 45646
18m, 59ft

--f15E
N 41°55.641', E 041°51.581'
37 T GG 37111 45664
18m, 59ft

--ka50-3
 41°55.7',  041°52.0'
18m, 59ft