### PR TITLE
apit addition: create/fix routetool presets, amsgs addition: reset msgs

### DIFF
--- a/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
+++ b/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
@@ -1736,6 +1736,17 @@ function wp(inp)
         return result .. "\n"
     elseif type(inp) == 'table' then
         loglocal('wp() inp table:'..net.lua2json(inp), 3)
+        local pos = Export.LoLoCoordinatesToGeoCoordinates(inp.y, inp.x)
+
+        local types = coordsType(unittype)
+        if types then
+            wp(LLtoAC(formatCoordConv(types.format, true, pos.latitude, types),
+                   formatCoordConv(types.format, false, pos.longitude, types),
+                   string.format("%.0f", inp.alt*3.28084)))
+        else
+            loglocal('wp() coordsType() returned nil, unittype: '..unittype)
+            return nil
+        end
     else
         loglocal('wp() unhandled arg type: '..type(inp))
     end
@@ -1826,6 +1837,7 @@ function loadDTCBuffer(text)
            itval = itval,
            dbglvl = dbgvlvl,
            kp = kp,
+           LT = LT,
            loglocal = loglocal,
            unittab = unittab,
            ttlist = ttlist,
@@ -1868,6 +1880,7 @@ function assignCustom()
                      ttf = ttf,
                      ttt = ttt,
                      delay = delay,
+                     LT = LT,
                      loglocal = loglocal,
                      switchPage = switchPage,
                      extid = extid,

--- a/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
+++ b/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
@@ -1,6 +1,6 @@
-local version=.63
+local version=.64
 local readme = [=[
-# aeronautes-pit (Apit)
+# aeronautes-pit (Apit) https://github.com/aeronautes/dcs-scratchpad
 
 This is an extension to github.com/rkusa/scratchpad for DCS. At a high
 level it provides the ability to configure your aircraft, assist with
@@ -1823,6 +1823,9 @@ function loadDTCBuffer(text)
            unittype = unittype,
            getinput = getinput,
            getTextarea = getTextarea,
+           extid = extid,
+           Scratchdir = Scratchdir,
+           Scratchpadfn = Scratchpadfn,
     }
     setmetatable(env, {__index = _G}) --needed to pickup all the
                                       --module macro definitions like
@@ -1856,6 +1859,13 @@ function assignCustom()
                      ttt = ttt,
                      delay = delay,
                      loglocal = loglocal,
+                     switchPage = switchPage,
+                     extid = extid,
+                     Scratchdir = Scratchdir,
+                     Scratchpadfn = Scratchpadfn,
+                     Apitlibdir = Apitlibdir,
+                     Apitlibsubdir = Apitlibsubdir,
+                     getTextarea = getTextarea,
         }
         --needed to pickup all the module macro definitions like
                                               --device/action

--- a/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
+++ b/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
@@ -94,7 +94,8 @@ supported by each.
   to press. These have been adapted for specific aircraft as each one
   has it's own particular sequence of input. The API for this includes
   wp(), wpseq(), press() and UI buttons `LL` and `wp`.
-  * Waypoint input is currently supported for A-10C, AV8,
+
+  * Waypoint input is currently supported for A-10C, AV8, CH-47,
   F-15E, F-16C, FA-18C, Hercules, Ka-50/3, OH-58
 
 - 5. Customizations are higher level capabilities that utilize any
@@ -104,8 +105,10 @@ supported by each.
   can modify these yourself to make your own customizations for your
   aircraft. They can be utilized by clicking on the function buttons,
   `1`, `2`, ...
-  * Customizations are provided for A-10C, AV8, F-15E, F-16C, FA-18C,
-  Hercules, Ka-50/3, Mi-8, Mi-24.
+
+  * Customizations are provided for A-10C, AV8, CH-47, F-15E, F-16C,
+  FA-18C, Hercules, Ka-50_3, Mi-8, Mi-24, OH-58, Combined Arms and
+  Global(applies to all modules)
 
 ## Installed File - Functionality map
 
@@ -171,16 +174,18 @@ supported by each.
   entered into the aircrafts coordinate input system. In F10 map view
   this is the location at center of the screen. In any other view,
   cockpit or external, it is the 3d location of the camera
-  position. Some aircraft may have prerequisites before using
-  `LatLon`. For example, F-18 currently requires Precise coordinates
-  enabled. Per module notes should describe these requires and is
-  viewable by pressing the button labeled with the name of the module,
-  eg Hercules, F-16C_50. The default behavior upon click is for the
-  sequencer to increment the current waypoint and enter latlong. The
-  next click will carry out the same steps. You can modify this
-  behavior using the wpseq() function(see below). You can also disable
-  wpseq() to prevent any waypoint number change, leaving it up to you
-  to set the correct number.
+  position. This button will be visible only for modules that are
+  supported and hidden for those that are not. Some aircraft may have
+  prerequisites before using `LatLon`. For example, F-18 currently
+  requires Precise coordinates enabled. Per module notes should
+  describe these requires and is viewable by pressing the button
+  labeled with the name of the module, eg Hercules, F-16C_50. The
+  default behavior upon click is for the sequencer to increment the
+  current waypoint and enter latlong. The next click will carry out
+  the same steps. You can modify this behavior using the wpseq()
+  function(see below). You can also disable wpseq() to prevent any
+  waypoint number change, leaving it up to you to set the correct
+  number.
 
 - `Sel` - This will take the current text selection as Lua. If no text
   is selected, then the current line the cursor is on is
@@ -209,7 +214,6 @@ supported by each.
   building a mission plan that can be reused or passed along.
 
 - `mod` - scratchpad will switch to the page named aeronautes-pit and
-
   overwrites the page with a copy of the module customization
   file. This is useful to see the module specific aeronautes-pit
   documentation as well as the code for the customization. This is
@@ -221,14 +225,14 @@ supported by each.
 - `modload` - Convenience and customization code for the current
   aircraft are immediately reloaded and made available. This is useful
   if you are modifying or adding apit Customization files
-  (Extensions\aeronautes-lib), or if you've messed up some certain values from a
+  (Extensions\aeronautes-lib), or if you've messed up certain values from a
   scratchpad page and want to reset using Customization file values.
 
 - `log` - aeronautes-pit keeps a log of it's execution in a buffer.
   Clicking this button switches to the scratchpad page aeronautes-pit
   and overwrites it with the log.
 
-- `loglvl` - This is used to increase the debug level of apit
+- `loglvl` - This is used to change the debug level of apit
   logging. Each click change the button label to indicate the level
   with a rollover to zero after 9.
 
@@ -237,7 +241,13 @@ supported by each.
 
 - `1`, `2`,... - These dynamic function buttons provide one-click
   access to functions defined in the per module customization files in
-  Scratchpad\Extensions\aeronautes-lib\<module>.lua. 
+  Scratchpad\Extensions\aeronautes-lib\<module>.lua. The button titles
+  will match the name of the function. The number of buttons will vary
+  based on how many functions are defined in the associated Lua custom
+  file. The first row of buttons below 'modload' are indented and
+  specifically for the loaded module. The second row of buttons below
+  'modload' are for functions defined in Globalcustom.lua. These exist
+  no matter what module is loaded.
 
 ## apit API
     The Lua functions provided by apit are as follows:

--- a/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
+++ b/Scripts/Scratchpad/Extensions/Disabled/aeronautes-pit.lua
@@ -469,10 +469,12 @@ local ttlist = {}               -- tool tips from clicabledata.lua
 -- butt vars below control the apit UI buttons created in scratchpad
 local butts = {}
 local buttfn = {} -- indirection funcs to bind to onClick by vary with assignCustom()
-local buttfnamt = 10            -- number of assignable custom function buttons
+local buttfnlimit = 10 -- limit on each of global and module button funcs
+local buttfnamt = 20            -- number of assignable custom function buttons
 local buttw = 50
 local butth = 30
 local panelbytitle = {}
+local Globalcustomfile = Apitlibdir..'Globalcustom.lua'
 
 Spinr = {
     frames = {'/','|','\\','-'},
@@ -1819,6 +1821,8 @@ function loadDTCBuffer(text)
            ttlist = ttlist,
            panel = panel,
            unittype = unittype,
+           getinput = getinput,
+           getTextarea = getTextarea,
     }
     setmetatable(env, {__index = _G}) --needed to pickup all the
                                       --module macro definitions like
@@ -1834,10 +1838,80 @@ function loadDTCBuffer(text)
 end                             -- end of loadDTCBuffer()
 
 function assignCustom()
-    local infn = Apitlibdir ..unittype..'.lua'
-    loglocal('aeronautespit: using customfile '..infn, 1)
 
-    for i,j in pairs(panel) do
+    function doCustom(infn)
+        loglocal('aeronautespit: using customfile '..infn, 1)
+
+        local ok, res
+        local funclist = {}
+        local env = {push_stop_command = push_stop_command,
+                     push_start_command = push_stop_command,
+                     prewp = prew,
+                     wp = wp,
+                     wpseq = wpseq,
+                     press = press,
+                     tt = tt,
+                     ttn = ttn,
+                     ttf = ttf,
+                     ttt = ttt,
+                     delay = delay,
+                     loglocal = loglocal,
+        }
+        --needed to pickup all the module macro definitions like
+                                              --device/action
+        setmetatable(env, {__index = _G})
+
+        ok, res =  apcall({fn=infn, env = env})
+
+        if ok then
+            if not res then
+                loglocal('doCustom() res nil ')
+                return
+            end
+
+            local fnadded = 0
+            if res.order then
+                local fname = ''
+                for i=1,#res.order do
+                    if fnadded >= buttfnlimit then
+                        loglocal('assignCustom() ordered func limit reached('..buttfnlimit..'), no more funcs added; file: '..infn)
+                        break
+                    end
+                    fname = res.order[i]
+                    if type(res[fname]) == 'function' then
+                        fnadded = fnadded + 1
+                        funclist[fnadded] = {name = fname, fn = res[fname]}
+                    else
+                        loglocal('doCustom() order name not function: '..fname..', file: '..infn)
+                    end
+                end             -- end for #res.order
+            else
+                for fname,_ in pairs(res) do
+                    if fnadded >= buttfnlimit then
+                        loglocal('assignCustom() ordered func limit reached('..buttfnlimit..'), no more funcs added; file: '..infn)
+                        break
+                    end
+                    if type(res[fname]) == 'function' then
+                        fnadded = fnadded + 1
+                        funclist[fnadded] = {name = fname, fn = res[fname]}
+                    end
+                end
+            end                 -- end if res.order
+
+            if res['init'] and type(res['init']) == 'string' then -- run custom init
+                loglocal('assignCustom() running unit init', 4)
+                loadDTCBuffer(res['init'])
+            end
+
+            return ok, res, funclist
+        end                     -- end ok
+    end                         -- end doCustom()
+
+    for i,j in pairs(buttfn) do -- re/initialize indirection funcs
+        buttfn[i] = nil
+    end
+
+    for i,j in pairs(panel) do  -- initialize panelbytitle
         if string.match(j.title, '^%d+$') then
             j.button:setText(j.title)
             j.button:setVisible(false)
@@ -1847,77 +1921,41 @@ function assignCustom()
         end
     end
 
-    local env = {push_stop_command = push_stop_command,
-               push_start_command = push_stop_command,
-               prewp = prew,
-               wp = wp,
-               wpseq = wpseq,
-               press = press,
-               tt = tt,
-               ttn = ttn,
-               ttf = ttf,
-               ttt = ttt,
-               delay = delay,
-               loglocal = loglocal,
-    }
-    setmetatable(env, {__index = _G})     --needed to pickup all the
-                                          --module macro definitions
-                                          --like device/action
+    local ok, res, funs
 
-    local ok, res = apcall({fn=infn, env = env})
+    local infn = Apitlibdir ..unittype..'.lua'
+    ok, res, funs  = doCustom(infn)
 
     if ok then
-        unittab = res
-        for i,j in pairs(buttfn) do
-            buttfn[i] = nil
+        for i=1,#funs do -- add module custom funcs to buttons 1-10
+            buttfn[i] = funs[i].fn
+            panelbytitle[tostring(i)].button:setText(funs[i].name)
+            panelbytitle[tostring(i)].button:setVisible(true)
         end
-        local idx = 0
+    else
+        loglocal('assignCustom() not ok infn: '..infn)
+    end                         -- end ok
 
-        if not unittab then
-            loglocal('assignCustom() res/unittab nil ')
-            return
+    infn = Globalcustomfile
+    ok, res, funs  = doCustom(infn)
+    if ok then
+        local j
+        for i=1,#funs do -- add module custom funcs to buttons 11-20
+            j = i + 10
+            buttfn[j] = funs[i].fn
+            panelbytitle[tostring(j)].button:setText(funs[i].name)
+            panelbytitle[tostring(j)].button:setVisible(true)
         end
+    else
+        loglocal('assignCustom() not ok infn: '..infn)
+    end                         -- end ok
 
-        if unittab.order then
-            loglocal('assignCustom() unittab.order: '..net.lua2json(unittab.order), 2)
-            local fname = ''
-            for i=1,#unittab.order do
-                fname = unittab.order[i]
-                if type(unittab[fname]) == 'function' then
-                    buttfn[i] = unittab[fname]
-                    panelbytitle[tostring(i)].button:setText(fname)
-                    panelbytitle[tostring(i)].button:setVisible(true)
-                else
-                    loglocal('assignCustom() order name not function: '..fname)
-                end
-            end
-        else
-            loglocal('assignCustom() no unittab.order detected, adding all functions '..unittype)
-            for i,j in pairs(unittab) do
-                if type(j) == 'function' then
-                    idx = idx + 1
-                    buttfn[idx] = j
-                    panelbytitle[tostring(idx)].button:setText(i)
-                    panelbytitle[tostring(idx)].button:setVisible(true)
-                end
-            end
-        end
-        
-        loglocal('assignCustom #unittab: '..#unittab ..': '.. unittype)
-        Spinr:rest()
-
-        if LT[unittype]['wpentry'] then
+    if panelbytitle['LatLon'] then -- toggle LatLon button based on aircraft capability
+        if unittype and LT[unittype] and LT[unittype]['wpentry'] then
             panelbytitle['LatLon'].button:setVisible(true)
         else
             panelbytitle['LatLon'].button:setVisible(false)
         end
-        
-        if unittab['init'] and type(unittab['init']) == 'string' then
-            loglocal('assignCustom() running unit init', 4)
-            loadDTCBuffer(unittab['init'])
-        end
-    else
-        loglocal('assignCustom apcall fail, ok: '..type(ok)..' res: '..type(res))
     end
 end                             -- end of assignCustom()
 
@@ -2124,10 +2162,12 @@ function getCurrentLineOffsets(text, cur)
 
     for i = cur, 0, -1 do
         if text:byte(i) == nl then
+            linestart = linestart + 1
             break
         end
         linestart = linestart - 1
-        if linestart == 0 then
+        if linestart <= 0 then
+            linestart = 1
             break
         end
     end
@@ -2142,20 +2182,26 @@ function getCurrentLineOffsets(text, cur)
     return linestart, lineend
 end                             -- end of getCurrentLineOffsets()
 
+local function getinput()
+    local text = getTextarea():getText()
+    local startp, endp, start, eos = getSelection()
+
+    loglocal('getinput() sp: '..startp..' ep: '..endp..' start: '..start..' eos: '..eos, 4)
+    if start == eos then    -- if nothing is highlighted use the current line of cursor
+        start, eos = getCurrentLineOffsets(text, eos)
+    else
+        start = start + 1
+    end
+
+    local sel = string.sub(text, start, eos)
+    loglocal('getinput() Sel len: '..string.len(sel)..' start: '..start..' end: '..eos..': #'..sel..'#', 4)
+
+    return sel
+end
+
 local function handleSelection(TA)
-        local text = TA:getText()
-        local startp, endp, start, eos = getSelection()
-
-        loglocal('handleSelection() sp: '..startp..' ep: '..endp..' start: '..start..' eos: '..eos)
-        if start == eos then    -- if nothing is highlighted use the current line of cursor
-            start, eos = getCurrentLineOffsets(text, eos)
-        end
-
-        sel = string.sub(text, start, eos)
-
-        loglocal('Sel len: '..string.len(sel)..' start: '..start..' end: '..eos..': #'..sel..'#')
-
-        local jtest = sel
+    local sel = getinput(TA)
+    local jtest = sel
         jtest = string.gsub(jtest, "[']", '')
         jtest = string.gsub(jtest, '°', ' ')
         local lat, lon = string.match(jtest, '(%u %d%d +%d%d%.%d+), (%u %d+ +%d%d%.%d+)')
@@ -2307,7 +2353,7 @@ function showCustom(TA)
 end                             -- end showCustom()
 
 function createbuttons()
-    local numbutts = 10
+    local numbutts = 10         -- number of static buttons, LatLon - modload
     local rowh = 0
 
     local buttx = 0
@@ -2411,14 +2457,33 @@ function createbuttons()
         loglocal('aeronautespit: reload click '..#LT)
         assignKP()
         assignCustom()
+        assignCustom(Globalcustomfile)
     end
 
     --start row of "dynamic" buttons after static buttons above
-    rowh = rowh + butth
-    buttw = buttw + 20
-    for i=1,buttfnamt do
+    -- module related dynamic functions
+    rowh = rowh + butth         -- increment row
+    buttw = buttw + 20          -- slightly wider to handle longer button titles
+    for i=1,10 do               -- indent row by 10
         butts[numbutts+i] = {((i-1)*buttw)+10, rowh, buttw, butth, tostring(i)}
-        butts[numbutts+i][6] = function(text) if buttfn[i] then buttfn[i](text); domacro.flag = true end end
+        butts[numbutts+i][6] = function(T)
+            if buttfn[i] then
+                buttfn[i](getinput())
+                domacro.flag = true
+            end
+        end
+    end
+
+    --universal functions not module related
+    rowh = rowh + butth         -- increment row
+    for i=11,buttfnamt do
+        butts[numbutts+i] = {((i-11)*buttw), rowh, buttw, butth, tostring(i)}
+        butts[numbutts+i][6] = function(T)
+            if buttfn[i] then
+                buttfn[i](getinput())
+                domacro.flag = true
+            end
+        end
         --[[ attempt at runtime generation of indirection func table for dynamic function buttons
             local str = 'function a'..i..'(text) if buttfn['..i..'] then buttfn['..i..'](text) end end'
             local fn
@@ -2433,6 +2498,7 @@ function createbuttons()
     for i,j in pairs(butts) do      -- create all buttons
         addButton(j[1], j[2], j[3], j[4], j[5], j[6])
     end
+
 end                             -- end createbuttons
 
 createbuttons()

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/AV8BNA.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/AV8BNA.lua
@@ -17,7 +17,10 @@ ft['mapoff'] = function()
 end
 
 ft['start'] = function(action)
-    if type(action) == 'table' then
+    local valid = {engspool='engspool', posteng='posteng'}
+    action = valid[action] or ''
+
+    if action == '' then
 
         -- Beginning of start procedure
 

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/F-15ESE.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/F-15ESE.lua
@@ -125,7 +125,10 @@ end --end of mpd()
 
 ft['firstspool'] = true
 ft['start'] = function (action)
-    if type(action) == 'table' then
+    local valid = {engspool='engspool', posteng='posteng'}
+    action = valid[action] or ''
+
+    if action == '' then
         ft['T1'] = DCS.getRealTime()
 
         -- Beginning of start procedure

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/F-16C_50.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/F-16C_50.lua
@@ -24,7 +24,10 @@ ft.order = {'start', 'setup', 'WIP-mfd', 'DEPREC-fence'}
 -- knob to NAV
 
 ft['start'] = function(action)
-    if type(action) == 'table' then
+    local valid = {engspool='engspool', posteng='posteng'}
+    action = valid[action] or ''
+
+    if action == '' then
 
         -- Beginning of start procedure
 

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/FA-18C_hornet.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/FA-18C_hornet.lua
@@ -170,7 +170,10 @@ end
 
 local ctr = 1
 ft['start'] = function (action)
-    if type(action) == 'table' then
+    local valid = {reng='reng', postreng='postreng',leng='leng', postleng='postleng',}
+    action = valid[action] or ''
+
+    if action == '' then
 -- Beginning of start procedure
 
 tt('Ejection Seat SAFE/ARMED Handle, SAFE/ARMED',{value=-1})

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Globalcustom.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Globalcustom.lua
@@ -1,0 +1,301 @@
+--[[
+    presetwp - used on Grayflag servers given an objective name,
+    produces additions to route tool preset file. DCS only reads
+    'Saved Game\DCS\Config\RouteToolPresets' after the mission loads
+    when joining server. This means any update wont show up in game
+    until the next server join. The script will merge it's additions
+    but you may choose to backup your presets if you value any of the
+    previous settings. Alternatively you can delete the file in the
+    RouteToolPresets directory to quickly initialize settings or use
+    the RouteTools F10 menu to delete individual routes. No gaurantees
+    are made with the use of this software.
+    
+    To use, highlight the name of the objective in scratchpad then
+    click the presetwp button. Information messages will be posted in
+    game chat window. Do as many objectives as you want then leave and
+    rejoin server and you should see the new presets in the drop down
+    list. This extension has the capability to pass the entire line as
+    input objective name if you dont highlight anything. For presetwp
+    that means you need a line with only the name of the objective,
+    place the cursor anywhere on that line and click the
+    button. Otherwise, on Grayflag servers, if you make an F10 'update'
+    label and click on the aeronautes-msg extension's trigger button
+    you can highlight the objective names.
+--]]
+
+
+local ft = {}
+ft.order = {'presetwp'}
+
+local function copytable(src)
+    dst = {}
+    for i, j in pairs(src) do
+        dst[i] = j
+    end
+    return dst
+end
+
+local function bsearch(tbl, len, value, cmpf)
+    local left = 1
+    local right = len+1
+    local mid
+
+    while(left < right) do
+        mid = left + math.floor((right - left)/2)
+--                loglocal('BSEARCH: '..value..' left: '..left..', '..mid..', '..right..net.lua2json(tbl[mid]))
+        if (cmpf(tbl[mid], value)) then
+            left = mid + 1
+        else
+            right = mid
+        end
+    end
+    return mid
+end                         -- end bsearch
+
+local function boundingbox(verts)
+    local bbox = {}
+    bbox = {minx = math.huge, miny = math.huge, maxx = -math.huge, maxy = -math.huge}
+
+    for i,v in pairs(verts) do
+        bbox.minx = math.min(bbox.minx, v.x)
+        bbox.maxx = math.max(bbox.maxx, v.x)
+
+        bbox.miny = math.min(bbox.miny, v.y)
+        bbox.maxy = math.max(bbox.maxy, v.y)
+    end
+    return bbox
+end
+
+local function umsg(str)
+    loglocal('Globalcustom: '..str)
+    net.recv_chat(str)
+end
+
+function trim(s)                -- https://lua-users.org/wiki/StringTrim
+   return s:match'^%s*(.*%S)' or ''
+end
+
+--#################################
+-- presetwp v0.1
+-- creates presets for route tool using objectives and cap zones as
+-- implmented on Grayflag server missions. This means missions using
+-- zones with 'property' 'type' 'obj' or 'qrf' and zones with
+-- 'property' 'str' 'CAP...'. This may work on other missions that
+-- follow this convention.
+
+ft['presetwp'] = function(input)
+    input = trim(input)
+    if not input then
+        umsg('No objective name supplied. You must highlight the objective name in scratchpad. "'..input..'"')
+        return
+    end
+
+    local presetfn = lfs.writedir()..[[Config\RouteToolPresets\]].._current_mission.mission.theatre..'.lua'
+    local objs = {}
+    local caps = {}
+    local qrfsup = {}
+    
+    for _,i in pairs(_current_mission.mission.triggers.zones) do
+        local zone = {}
+        zone = {name = i.name, x = i.x, y = i.y, zoneid = i.zoneId}
+        if i.properties and i.properties[1] and i.properties[1]['key'] then
+            for _,j in pairs(i.properties) do
+                zone[j.key] = j.value
+            end
+        end
+        if i.verticies then
+            zone['verticies'] = copytable(i.verticies)
+        end
+
+        if zone.type == 'obj' then
+            table.insert(objs, zone)
+        elseif zone.type == 'qrf' or zone.type == 'supply' then
+            table.insert(qrfsup, zone)
+        elseif string.sub(zone.name, 1, 3) == 'CAP' then
+            table.insert(caps, zone)
+        end
+    end
+    table.sort(caps, function(a,b) return a.x < b.x end)
+    loglocal('caps:'..#caps.. ' objs: '..#objs.. ' qrfsup: '..#qrfsup, 4)
+
+    local objlist = {}
+    loglocal('input: #'..input..'#', 4)
+    for i,j in pairs(objs) do
+        if j.str == input then
+            table.insert(objlist, j)
+        end
+    end
+
+    if #objlist == 0 then
+        umsg('Objective not found: #'..input..'# '..#objlist)
+        return
+    end
+    if #objlist > 1 then
+        umsg('Multiple objectives found: '..input..' ('..#objlist..')')
+    end
+    
+    for i,obtgt in pairs(objlist) do
+--        loglocal('OBJ: '..net.lua2json(obtgt))
+        local bb = boundingbox(obtgt.verticies)
+--        loglocal('BB: '..net.lua2json(bb))
+
+        -- DCS x axis is vertical, y horizontal
+        local minx = bsearch(caps, #caps, bb.minx, function(a,b) return a.x < b end)
+        local maxx = bsearch(caps, #caps, bb.maxx, function(a,b) return a.x < b end)
+        loglocal('RESX: '..minx .. ' , '..maxx, 4)
+        local xrng = {}
+
+        for i=minx,maxx do
+            table.insert(xrng, caps[i])
+--            loglocal('Xrng(x): '..i..' ; '..net.lua2json(caps[i]))
+        end
+        table.sort(xrng, function(a,b) return a.y < b.y end)
+        
+        local miny = bsearch(xrng, #xrng, bb.miny, function(a,b) return a.y < b end)
+        local maxy = bsearch(xrng, #xrng, bb.maxy, function(a,b) return a.y < b end)
+        loglocal('RESY: '..miny .. ' , '..maxy, 4)
+        for i=miny, maxy do
+            loglocal(i..' BBOXED result: '..net.lua2json(xrng[i]), 4)
+        end
+
+        -- caps in obj test
+        local objwp = {}
+        for i=miny, maxy do
+            local intcount = 0
+
+            function intersect(P1, y2, P3, P4)
+                -- Line1
+                local x1 = P1.y; local y1 = P1.x
+                --local y2 = y2
+
+                -- Line2
+                local x3 = P3.y; local y3 = P3.x
+                local x4 = P4.y; local y4 = P4.x
+
+                denom = ((y1 - y2)*(x3 - x4))
+                t = ((x1 - x3)*(y3 - y4)-(y1 - y3)*(x3 - x4)) / denom
+                u =                       -((y1-y2)*(x1 - x3)) / denom
+
+                --            loglocal(P1.name..' P1: '..P1.x..','..P1.y..' my: '..y2..' v1: '..net.lua2json(P3)..' v2: '..net.lua2json(P4))
+                --            loglocal('poly: denom: '..denom..' t: '..t..' u: '..u)
+                if 0 <= t and t <= 1.0 and 0 <= u and u <= 1.0 then
+                    return 1
+                else
+                    return 0
+                end
+            end
+
+            for j=1,3 do
+                intcount = intcount + intersect(xrng[i], bb.maxy, obtgt.verticies[j], obtgt.verticies[j+1])
+--                loglocal(j..' INTERSECT: '..intcount)
+            end
+            intcount = intcount + intersect(xrng[i], bb.maxy, obtgt.verticies[4], obtgt.verticies[1])
+--            loglocal('4 INTERSECT: '..intcount)
+
+            if math.mod(intcount, 2) == 0 then
+                loglocal('OUTSIDE POLY, passing '..net.lua2json(xrng[i]), 4)
+            else
+                loglocal('Inside poly inserting '..net.lua2json(xrng[i]), 4)
+                table.insert(objwp, xrng[i])
+            end
+        end                         -- end i=miny, maxy
+
+        if #objwp == 0 then
+            umsg('Objective waypoints size zero, no presets designated, '..input..' ('..obtgt.name..')')
+            return
+        end
+        table.sort(objwp, function(a,b) return a.x < b.x end) -- sort wp from south increasing to north
+
+        -- create and merge new presets with current presets file
+        if not presets then
+            local atr = lfs.attributes(presetfn)
+            if atr and atr.mode == 'file' then
+                dofile(presetfn)
+            end
+            if not presets then
+                presets = {}
+            end
+        end
+        local rt = DCS.getMissionName()..'-v'.._current_mission.mission.version..'-'
+        if obtgt.lat then
+            rt = rt..'Lat'..obtgt.lat..'-'
+        end
+        rt = rt .. obtgt.str
+        if #objlist > 1 then    -- add objective name if there are multiple obj with same str
+            rt = rt .. '-'..obtgt.name
+        end
+        
+        local etatot = 900
+        presets[rt] = {}
+        local pretmp = {
+            alt = 2000,
+            type =  "Turning Point",
+            ETA = etatot,
+            ETA_locked = true,
+            y = 0,
+            x = 0,
+            name = "",
+            speed_locked = false,
+            alt_type = "BARO",
+            action = "Turning Point",
+        }
+
+        for wp=1,#objwp do
+--            loglocal('OH: '..wp..' ; '..net.lua2json(objwp[wp]))
+            presets[rt][wp] = copytable(pretmp)
+            presets[rt][wp].name = objwp[wp].str
+            presets[rt][wp].x = objwp[wp].x
+            presets[rt][wp].y = objwp[wp].y
+            if wp > 1 then        -- formula from Scripts\UI\RouteTool.lua
+                presets[rt][wp].ETA = etatot + math.sqrt((objwp[wp-1].x - objwp[wp].x)^2 + (objwp[wp-1].y - objwp[wp].y)^2) / 70 --250km/h
+                etatot = presets[rt][wp].ETA
+--                loglocal('ETA: '..presets[rt][wp].ETA)
+            end
+        end                         -- end pairs(objwp)
+        umsg(#objwp..' wps created for '..rt)
+    end -- obtgt in pairs(objlist)
+    
+    -- write new presets
+    local file, err = io.open(presetfn, 'w+')
+    if err then
+        umsg("Error writing file: " .. presetfn)
+        return
+    end
+    function fout(str)
+        --        loglocal(str)
+        file:write(str)
+    end
+
+    local presort = {}
+    for i,j in pairs(presets) do
+        table.insert(presort, i)
+    end
+    table.sort(presort)
+    
+    fout('presets =\n{\n')
+    for i=1, #presort do
+        loglocal(i..' SORT: '..presort[i], 4)
+        local rtname = presort[i]
+        local rtnode = presets[rtname]
+        fout('    ["'..rtname..'"] =\n    {\n') -- route
+        for wpnum=1,#rtnode do
+            fout('        ['..wpnum..'] =\n        {\n') --wp
+            for key,value in pairs(rtnode[wpnum]) do
+                if type(value) == 'string' then
+                    fout('            ["'..key..'"] = "'..value..'",\n')
+                else
+                    fout('            ["'..key..'"] = '..tostring(value)..',\n')
+                end
+            end
+            fout('        }, -- end of ['..wpnum..']\n')
+        end
+        fout('    }, -- end of ["'..rtname..'"]\n')
+    end
+    fout('} -- end of presets')
+    file:flush()
+    file:close()
+
+    umsg('DCS only reads presets file on mission load. You must leave/rejoin server for new presets')
+end                             -- end ft[a]
+
+return ft

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Hercules.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Hercules.lua
@@ -1,5 +1,14 @@
 --[[ working functions:
 
+    Prerequisite:
+    https://github.com/aeronautes/Hercules-6.8.2-macrofix/archive/refs/heads/main.zip
+    You will need to install this macrofix to enable the Anubis Herc
+    mod to use the macro interface. Unzip it's contents into the
+    location of your Herc mod, ie: "Saved
+    Games\DCS\Mods\aircraft\Hercules ver 6.8.2" directory. Note "DCS"
+    directory might be slightly different on your system such as
+    DCS.openbeta.
+
     start - start engines, currently uses ground elec/air, so timing
     cant clash with other ground orders. Just make sure you start
     engines before doing anything else like rearming or fueling. This
@@ -30,8 +39,8 @@
 
     night - set lighting for night flying
 
-    pivot - log to Scratchpad.log the required speed for current
-    altitude to do pivot turn
+    pivot - display in game chat and log to Scratchpad.log the
+    required speed for current altitude to do pivot turn
 --]]
 
 -- module specific configuration

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Hercules.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Hercules.lua
@@ -40,26 +40,7 @@ wpseq({cur=1,
 })
 
 local ft = {}
-ft.order = {'test','start', 'takeoff', 'landing', 'night', 'pivot'}
-
-ft['test'] = function()
-    local objs = {}
-    for _,j in pairs(_current_mission.mission.triggers.zones) do
-        if j.type == 2 then
-            local ob = {}
-            ob = {['name'] = j.name, ['x'] = j.x, ['y'] = j.y}
-            for _,l in pairs(j.properties) do
-                ob[l.key] = l.value
-            end
-            table.insert(objs, ob)
-        end
-    end
-
-    table.sort(objs, function(a,b) return a.x < b.x end)
-    for _,j in pairs(objs) do
-        loglocal(net.lua2json(j))
-    end
-end
+ft.order = {'start', 'takeoff', 'landing', 'night', 'pivot'}
 
 --#################################
 -- pivot v0.1
@@ -120,7 +101,10 @@ end                             -- end night
 -- need to start in reverse numerical order, primarily engine 1 or 2 needs to be last to start
 
 ft['start'] = function(action)
-    if type(action) == 'table' then
+    local valid = {engspool='engspool', posteng='posteng'}
+    action = valid[action] or ''
+
+    if action == '' then
 
         -- Beginning of start procedure
 

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Ka-50_3.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Ka-50_3.lua
@@ -19,8 +19,11 @@ wpseq({ cur = 1,
 
 --]]
 ft['start'] = function(arg)
+    local valid = {reng='reng', leng='leng', posteng='posteng', apudown='apudown'}
+    arg = valid[arg] or ''
+
     local dbl = 0
-    if type(arg) == 'table' then
+    if arg == '' then
         ft['T1'] = DCS.getRealTime()
 
 --front panel next to abris

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Mi-24P.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Mi-24P.lua
@@ -13,7 +13,10 @@ ft = {}
 [04:26:01] posteng time: 54.3704036
 --]]
 ft['start'] = function(arg)
-    if type(arg) == 'table' then
+    local valid = {reng='reng', leng='leng', posteng='posteng'}
+    arg = valid[arg] or ''
+
+    if arg == '' then
         ft['T1'] = DCS.getRealTime()
     
 ttf('Pilot Door Safety Lock, OPEN/CLOSE')

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Mi-8MT.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Mi-8MT.lua
@@ -10,7 +10,10 @@
 
 ft = {}
 ft['start'] = function (action)
-    if type(action) == 'table' then
+    local valid = {reng='reng', leng='leng', postreng='postreng', postleng='postleng'}
+    action = valid[action] or ''
+
+    if action == '' then
 -- Beginning of start procedure
 
         net.recv_chat('Starting Mi-8')


### PR DESCRIPTION
apit:
- Added Globalcustom.lua for dynamic button functionality similar to module customizations but these apply across any modules the user owns. 
- First Globalcustom button, 'presetwp', will create RouteTool preset routes based on mission definition of objectives and cap zones. Currently supports Grayflag mission type. A new row of dynamic buttons added for these.
- New dynamic button, 'presetfix', will set any manually created RouteTool altitudes to their actual ground height above MSL. By default DCS sets this to 2000m. This is not necessary for 'presetwp' created routes.

amsgs:
- Message type buttons are now dynamic and will change to all caps to indicate unread mesgs and lower case for mesgs read.
- Reset button will clear the mesg buffers. Buffers also reset on mission load end, so anytime joining a server.