### PR TITLE
Apit change to button layout, F15E route handling, dot reticle, minor fixes/formatting

### DIFF
--- a/Scripts/Scratchpad/Extensions/Disabled/aeronautes-msgs.lua
+++ b/Scripts/Scratchpad/Extensions/Disabled/aeronautes-msgs.lua
@@ -98,7 +98,9 @@ local function bufradd(arg, msg)
     local dateStr = string.format('[%i:%02i:%02i] ', date.hour, date.min, date.sec)
     arg.idx = arg.idx + 1
     arg.buf = arg.buf .. dateStr .. msg .. '\n'
-    arg.panel.button:setText(string.upper(arg.panel.title))
+    if arg.panel then
+        arg.panel.button:setText(string.upper(arg.panel.title))
+    end
 end
 
 local function showbuf(bufnm)

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/AV8BNA.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/AV8BNA.lua
@@ -6,9 +6,7 @@
 --]]
 
 -- module specific configuration
-wpseq({cur=1,
-       diff = 1,
-})
+wpseq({enable=true, cur=1, diff = 1,})
 
 ft ={}
 ft.order={'start', 'setup', 'maptoggle', 'night'}
@@ -28,6 +26,33 @@ ttn('MPCD Left Button 3')
 end
 
 --#################################
+-- setup v0.2
+-- cockpit setup that can be used after startup or module autostart
+ft['setup'] = function(input)
+
+tt('Seat Ground Safety Lever')
+tt('Flaps Power Switch',{value=.5})
+tt('RWR Power/Volume Button',{value=.5})
+tt('Decoy Dispenser Control',{value=.4})
+tt('Jammer Control',{value=.2})
+
+ttt('MPCD Left Button 2')
+tt('Display Brightness Control',{value=.9})
+tt('HUD Off/Brightness Control',{value=1})
+tt('Parking Brake Lever')
+ttn('STO Stop Lever')
+
+tt('Comm 1 Volume Control', {value=.7})
+tt('Comm 2 Volume Control', {value=.7})
+tt('Master Arm Switch')
+tt('DMT Toggle On/Off')
+
+ttn('FLIR Power Switch')
+tt('INS Mode Knob',{value=.4})
+
+end                         -- end setup
+
+--#################################
 -- start v0.2
 -- start the jet; Master Caution will engage after this finishes
 ft['firstspool'] = true
@@ -40,7 +65,7 @@ ft['start'] = function(action)
         -- Beginning of start procedure
         net.recv_chat('AV8 start, throttle off')
 ttn('Canopy Handle')
-ttn('Oxygen Switch',{})
+ttn('Oxygen Switch')
 tt('Battery Switch')
 tt('Throttle Cutoff Lever')
 Export.LoSetCommand(2004,1)     --throttle off
@@ -54,6 +79,7 @@ tt('MPCD Left Off/Brightness Control')
 tt('MPCD Right Off/Brightness Control')
 ttt('MPCD Right Button 11')
 tt('Engine Start Switch')
+tt('Parking Brake Lever')
 
     ft['start']('engspool')
     elseif action == 'engspool' then
@@ -77,7 +103,7 @@ tt('Engine Start Switch')
             end
         end
     elseif action == 'posteng' then
-
+---[[
 tt('Seat Ground Safety Lever')
 tt('Flaps Power Switch',{value=.5})
 tt('RWR Power/Volume Button',{value=.5})
@@ -86,33 +112,30 @@ tt('Jammer Control',{value=.2})
 
 ttt('MPCD Left Button 2')
 tt('Display Brightness Control',{value=.9})
-tt('HUD Off/Brightness Control',{value=.5})
+tt('HUD Off/Brightness Control',{value=1})
 tt('Parking Brake Lever')
-tt('STO Stop Lever',{value=.65})
+ttn('STO Stop Lever')
 
 tt('Comm 1 Volume Control', {value=.7})
 tt('Comm 2 Volume Control', {value=.7})
 tt('Master Arm Switch')
 tt('DMT Toggle On/Off')
-
---INS align
 tt('INS Mode Knob',{value=.4})
+
+--]]
+        --INS align
+
+--        tt['setup']()
+
     end                             -- posteng
 
 tt('Master Caution')
 end                             -- end of start
 
---#################################
--- setup v0.1
--- cockpit setup that can be used after startup or module autostart
-ft['setup'] = function(input)
 
-ttn('FLIR Power Switch')
-
-end                         -- end setup
 
 --#################################
--- night v0.1
+-- night v0.2
 -- turn on cockpit lights and NW light
 ft['night'] = function(input)
 
@@ -123,6 +146,13 @@ tt('Instruments Lights',{value=.3})
 tt('Console Lights',{value=.3})
 tt('Annunciator Lights',{value=.3})
 ttn('External Auxiliary Lights Switch')
+
+-- enable HUD FLIR
+ttn('FLIR Power Switch')
+tt('HUD Video Brightness Control', {value=.35})
+tt('HUD Video Contrast Control', {value=.55})
+ttn('HUD Display Mode Switch')
+ttt('',{action=hotas_commands.SSS_CENTER, device=devices.MSC})
 
 end                             -- end night
 

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/F-15ESE.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/F-15ESE.lua
@@ -7,7 +7,7 @@
 --]]
 
 -- module specific configuration
-wpseq({cur=1, diff = 1, route = '.B', menus = 'mlj'})
+wpseq({enable=true, cur=1, diff = 1, route = '.B', menus = 'mlj',})
 
 ft ={}
 ft.order={'start', 'mpd', 'A/Gload', 'night', 'day', 'route'}
@@ -88,31 +88,38 @@ ft['mpd'] = function ()
             ttt('Power Switch', {device=dev, onvalue=-1})
             for x,y in pairs(screen) do
                 if debug then
-                    loglocal('PROG: 6')
-                else
-                    ttt('Power Switch',{device=dev, action=button[6]})
+                    loglocal('F15E mpd: 1')
                 end
+                ttt('Power Switch',{device=dev, action=button[6]})
 
                 for i,j in pairs(menu[y[1]]) do
-                    if debug then loglocal('PAGE: '..y[1]..'='..y[2]..' j: '..j)
-                    else ttt('Power Switch',{device=dev, action=button[j]}) end
+                    if debug then
+                        loglocal('F15E mpd PAGE: '..y[1]..'='..y[2]..' j: '..j)
+                    end
+                    ttt('Power Switch',{device=dev, action=button[j]})
                 end
 
                 if type(y[2]) == 'string' and #y[2] == 3 then
                     for k=1, #menu2[y[2]] do
-                        if debug then loglocal('MM: '..menu2[y[2]][k])
-                        else ttt('Power Switch',{device=dev, action=button[menu2[y[2]][k]]}) end
+                        if debug then
+                            loglocal('F15E mpd MM: '..menu2[y[2]][k])
+                        end
+                        ttt('Power Switch',{device=dev, action=button[menu2[y[2]][k]]})
                     end
-                    if debug then loglocal('MM SET: '..menu[y[1]][#menu[y[1]]])
-                    else ttt('Power Switch',{device=dev, action=button[menu[y[1]][#menu[y[1]]]]}) end
-                    if debug then loglocal('MM3 finalize:2x 6')
-                    else ttt('Power Switch',{device=dev, action=button[6]}) end
+                    if debug then
+                        loglocal('F15E mpd MM SET: '..menu[y[1]][#menu[y[1]]])
+                    end
+                    ttt('Power Switch',{device=dev, action=button[menu[y[1]][#menu[y[1]]]]})
+                    if debug then
+                        loglocal('F15E mpd MM3 finalize:2x 6')
+                    end
+                    ttt('Power Switch',{device=dev, action=button[6]})
                 end  -- if type
             end --for x,y
         end --if screens
-    end --for tmp
+    end --for dev
 
-    if not debug then ttt('Power Switch',{device=de, action=button[6]}) end
+    ttt('Power Switch',{device=de, action=button[6]})
 
 end --end of mpd()
 
@@ -452,23 +459,22 @@ updateroute()
 -- route v0.10
 -- cycle through routes A-C for wp entry
 ft['route'] = function()
-    local w = wpseq()
+    if LT[unittype].nextroute then
+        local w = wpseq()
 
-    for i=14, 23 do
-        local j = panel[i]
-        local btext = string.sub(j['button']:getText(), 1, 5)
-        if btext == 'route' then
-            local nextrt = string.byte(string.sub(w.route, 2)) + 1
-            if nextrt > 67 then
-                nextrt = 65
+        for i=14, 23 do         -- look for route button
+            local j = panel[i]
+            local btext = string.sub(j['button']:getText(), 1, 5)
+            if btext == 'route' then
+                w.route = LT[unittype].nextroute[w.route]
+                j['button']:setText('route'..w.route)
+                wpseq(w)
+                return
             end
-            w.route = '.'..string.char(nextrt)
-            j['button']:setText('route'..w.route)
-            wpseq(w)
-            return
         end
+        loglocal('F-15E route() button not found')
     end
-    loglocal('F-15E route() button not found')
+
 end                             -- end route
 
 return ft

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Globalcustom.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Globalcustom.lua
@@ -1,6 +1,8 @@
 --[[ working functions: presetwp, presetfix
 
-    ## presetfix - This function will set the correct altitude for the
+    ## presetfix - DEPRECATED: Currently implemented in this file but
+       not defined or displayed.
+       This function will set the correct altitude for the
        waypoints of the currently loaded theater. It will only change
        altitudes set at 2000m as that is the DCS default. This will
        prevent the function from changing any altitudes the user has
@@ -51,7 +53,7 @@
 --]]
 
 local ft = {}
-ft.order = {'presetwp', 'presetfix', 'RTlist', 'RTload', 'RTshow', 'ammo', 'globalfile'}
+ft.order = {'presetwp', 'RTlist', 'RTload', 'RTshow', 'ammo', 'globalfile'}
 
 local presetfn = lfs.writedir()..[[Config\RouteToolPresets\]].._current_mission.mission.theatre..'.lua'
 
@@ -605,6 +607,9 @@ end                             -- end presetwp
 -- theater to the actual ground height for any altitudes set at
 -- 2000. This means if you set your own value in the altitude edit
 -- box, presetfix will not alter it.
+
+-- DEPRECATED 
+--[[
 ft['presetfix'] = function(input)
     loglocal('presetfix call', 2)
     readpresets()
@@ -628,6 +633,7 @@ ft['presetfix'] = function(input)
     end
     writepresets(presets)
 end                         -- presetfix
+--]]
 
 --#################################
 -- RTlist v0.1
@@ -721,6 +727,7 @@ CTLDunit = {
     ['Mi-24P']=1,
     ['Mi-8MT']=1,
     ['UH-1H']=1,
+    ['UH-60L']=1,
 }
 
 if CTLDunit[unittype] then

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Hercules.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Hercules.lua
@@ -41,7 +41,7 @@
 --]]
 
 -- module specific configuration
-wpseq({cur=1, diff = 1, })
+wpseq({enable=true, cur=1, diff = 1, })
 
 local ft = {}
 ft.order = {'start', 'takeoff', 'landing', 'night', 'pylon', 'cannon'}

--- a/Scripts/Scratchpad/Extensions/aeronautes-lib/Ka-50_3.lua
+++ b/Scripts/Scratchpad/Extensions/aeronautes-lib/Ka-50_3.lua
@@ -7,7 +7,7 @@
 ft = {}
 ft.order = {'start', 'setup', 'night'}
 
-wpseq({ cur = 1, diff = 1, route = 't', })
+wpseq({enable=true, cur = 1, diff = 1, route = 't', })
 
 --#################################
 -- setup v0.1


### PR DESCRIPTION
apit:
   - initial code for trie of cockpit controls Tool Tips strings
   - reduced max available buttons from 10 to 8 since wide window no longer a priority with previous word wrap bug fix
   - dot function/button that puts a dot reticle on screen, similar to what is displayed with L/L button
   - F15E gets route handling A-C and Base. You can switch which routes new waypoints get assigned to with click of route button
   - code formatting for consistency

alib:
   - AV8 gets a setup button and minor formattinog
   - F15E route button added to cycle thru A-C, Base for waypt input. Default starts on B
   - Globalfile presetfix is deprecated to reduce buttons. Uncomment to reinstate; UH-60 added as CTLD capable unit
   - minor format change for Hercules and Ka50

amsg:
   - minor fix for button text display before any msg buffers exist as on fresh client start and before joining server